### PR TITLE
Add hypercube config generator

### DIFF
--- a/src/braid_cli.erl
+++ b/src/braid_cli.erl
@@ -125,7 +125,8 @@ config(Type, Size, DockerImage) ->
     N = list_to_integer(Size),
     case Type of
         "mesh" -> braid_config:gen(mesh, DockerImage, N);
-        "ring" -> braid_config:gen(ring, DockerImage, N)
+        "ring" -> braid_config:gen(ring, DockerImage, N);    
+        "hypercube" -> braid_config:gen(hypercube, DockerImage, N)
     end.
 
 %--- Internal ------------------------------------------------------------------

--- a/src/braid_config.erl
+++ b/src/braid_config.erl
@@ -28,9 +28,7 @@ ring(DockerImage, Size) ->
 hypercube(DockerImage, N) ->
     Machines = fly_machines(),
     Vertices = gen_hypercube_vertices(N),
-    % io:format("~p~n", [Vertices]),
     Hypercube = connect_hypercube_vertices(N, Vertices),
-    % io:format("~p~n", [Hypercube]),
     FormattedHypercube = hypercube_to_string(Hypercube),
     CfgMap = gen_hypercube_containers(DockerImage, Machines, FormattedHypercube),
     ok = file:write_file("hypercube.config", io_lib:format("~p.~n", [CfgMap])).
@@ -116,13 +114,10 @@ gen_hypercube_vertices(N) ->
 
 connect_hypercube_vertices(N, Vertices) ->
     Masks = [round(math:pow(2, E)) || E <- lists:seq(0, N - 1)],
-    % io:format("Masks: ~p\n",[Masks]),
     [{V, find_neighbours(V, Masks)} || V <- Vertices].
 
 find_neighbours(Vertex, Masks) ->
-    Neighbours = [Vertex bxor M || M <- Masks],
-    % io:format("Neighbours of ~p : ~p\n",[Vertex, Neighbours]),
-    Neighbours.
+    [Vertex bxor M || M <- Masks].
 
 hypercube_to_string(Hypercube) ->
     [vertex_to_string(VE) ||VE <- Hypercube].
@@ -136,7 +131,6 @@ index_to_string(Integer) ->
 gen_hypercube_containers(Image, Machines, Hypercube) ->
     Sizes = divide_sizes_with_reminder(length(Hypercube), length(Machines)),
     Occupancy = lists:zip(Sizes, Machines),
-    % ContainerToMachine = map_machine_to_container(),
     rec_hypercube_containers(Image, Occupancy, Hypercube, #{}, []).
 
 rec_hypercube_containers(Image, [], [], N2M, MachineConfigs) -> 
@@ -161,5 +155,3 @@ rec_hypercube_containers(Image, [{Quantity, Machine} | Others],
                     || {Name, Connections} <- ToMachine],
     NewCfg = [{Machine, Containers} | Cfg],
     rec_hypercube_containers(Image, Others, Rest, maps:merge(NewN2M, N2M), NewCfg).
-
-    

--- a/src/braid_rest.erl
+++ b/src/braid_rest.erl
@@ -32,7 +32,6 @@ rpc(Instance, CID, M, F, A) ->
     BinF = base64:encode(term_to_binary(list_to_atom(F))),
     {ok, Tokens, _} = erl_scan:string(A ++ "."),
     {ok, Term} = erl_parse:parse_term(Tokens),
-    io:format("Parsed term: ~p\n",[Term]),
     BinArgs = base64:encode(term_to_binary(Term)),
     QS = [{"cid", CID}, {"m", BinM}, {"f", BinF}, {"args", BinArgs}],
     {Code, Result} = send_to_instance(get, Instance, "rpc", QS),


### PR DESCRIPTION
Allows to generate a configuration given the dimension of the hypercube.
Connections are populated correctly. Node names are the index of the vertex written in binary.
Node names of a square =  0, 1, 10, 11

`braid config hypercube <n> <image_name>`

Where n is the dimension
N = 1 -> segment
N = 2 -> square
N = 3 -> cube
N = 4 -> tesseract
N = 5 -> ...

```
> braid rpc 48ed771b7123e8 0861cff1-4950-470d-80bd-29d526cc13be braidsquid hypercube_travel "[1111]"
{200,<<"#{visited_nodes => [0,1000,1100,1110,1111,111,11,1,0]}">>}
```